### PR TITLE
Fix #41

### DIFF
--- a/salesforce-crm-for-abandoned-cart/soapclient/SforcePartnerClient.php
+++ b/salesforce-crm-for-abandoned-cart/soapclient/SforcePartnerClient.php
@@ -75,7 +75,7 @@ require_once ('SforceBaseClient.php');
 class SforcePartnerClient extends SforceBaseClient {
   const PARTNER_NAMESPACE = 'urn:partner.soap.sforce.com';
 	
-  function SforcePartnerClient() {
+  function __construct() {
     $this->namespace = self::PARTNER_NAMESPACE;
   }
   


### PR DESCRIPTION
This error message was shown because in php 7 we can't have the function name same as the class name

To fix the issue we have renamed the function as the construct.